### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "var server = require('./lib/server');server.start();"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# World of Farmcraft #
+https://repl.it/badge/github/joeyinbox/world-of-farmcraft # World of Farmcraft #
 
 An online multiplayer 3D isometric farm game built with Node.js
 


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@hcahoon01/world-of-farmcraft).